### PR TITLE
Basic remove curly braces from templates to migrate to expressions as a first-class language feature [#6]

### DIFF
--- a/src/main/java/org/openrewrite/terraform/terraform012/UseFirstClassExpressions.java
+++ b/src/main/java/org/openrewrite/terraform/terraform012/UseFirstClassExpressions.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.terraform.terraform012;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Incubating;
+import org.openrewrite.Recipe;
+import org.openrewrite.hcl.HclVisitor;
+import org.openrewrite.hcl.tree.Expression;
+import org.openrewrite.hcl.tree.Hcl;
+
+import java.util.List;
+
+/**
+ * @see <a href="https://www.hashicorp.com/blog/terraform-0-12-preview-first-class-expressions">https://www.hashicorp.com/blog/terraform-0-12-preview-first-class-expressions</a>
+ * @see <a href="https://www.terraform.io/upgrade-guides/0-12.html#first-class-expressions">https://www.terraform.io/upgrade-guides/0-12.html#first-class-expressions</a>
+ */
+@Incubating(since = "0.7.0")
+public class UseFirstClassExpressions extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Use first class expressions";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replace expressions using string interpolation template syntax (`\"${var.variable}\"`) " +
+                "to using first-class expression syntax (`var.variable`).";
+    }
+
+    @Override
+    protected HclVisitor<ExecutionContext> getVisitor() {
+        return new UseFirstClassExpressionsVisitor();
+    }
+
+    private static class UseFirstClassExpressionsVisitor extends HclVisitor<ExecutionContext> {
+        @Override
+        public Hcl visitQuotedTemplate(Hcl.QuotedTemplate template, ExecutionContext ctx) {
+            List<Expression> expressions = template.getExpressions();
+            if (!expressions.isEmpty()) {
+                Expression e = template.getExpressions().get(0);
+                if (e instanceof Hcl.TemplateInterpolation) {
+                    Hcl.TemplateInterpolation t = (Hcl.TemplateInterpolation) e;
+                    return t.getExpression().withPrefix(template.getPrefix());
+                }
+            }
+            return super.visitQuotedTemplate(template, ctx);
+        }
+    }
+
+}

--- a/src/main/java/org/openrewrite/terraform/terraform012/package-info.java
+++ b/src/main/java/org/openrewrite/terraform/terraform012/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NonNullApi
+@NonNullFields
+package org.openrewrite.terraform.terraform012;
+
+import org.openrewrite.internal.lang.NonNullApi;
+import org.openrewrite.internal.lang.NonNullFields;

--- a/src/main/resources/META-INF/rewrite/terraform012.yml
+++ b/src/main/resources/META-INF/rewrite/terraform012.yml
@@ -14,29 +14,11 @@
 # limitations under the License.
 #
 ---
-type: specs.openrewrite.org/v1beta/category
-name: Terraform 0.12
-packageName: org.openrewrite.terraform.terraform012
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.terraform.terraform012.UpgradeTerraform_0_12
+displayName: Upgrade to Terraform 0.12.+
+description: Upgrade to Terraform 0.12.+ from Terraform 0.11.latest.
 tags:
   - terraform
----
-type: specs.openrewrite.org/v1beta/category
-name: AWS
-packageName: org.openrewrite.terraform.aws
-tags:
-  - terraform
-  - AWS
----
-type: specs.openrewrite.org/v1beta/category
-name: GCP
-packageName: org.openrewrite.terraform.gcp
-tags:
-  - terraform
-  - GCP
----
-type: specs.openrewrite.org/v1beta/category
-name: Azure
-packageName: org.openrewrite.terraform.azure
-tags:
-  - terraform
-  - Azure
+recipeList:
+  - org.openrewrite.terraform.terraform012.UseFirstClassExpressions

--- a/src/test/kotlin/org/openrewrite/terraform/terraform012/UseFirstClassExpressionsTest.kt
+++ b/src/test/kotlin/org/openrewrite/terraform/terraform012/UseFirstClassExpressionsTest.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.terraform.terraform012
+
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import org.openrewrite.Issue
+import org.openrewrite.Recipe
+import org.openrewrite.hcl.HclRecipeTest
+
+@Suppress("RemoveCurlyBracesFromTemplate")
+@Issue("https://github.com/openrewrite/rewrite-terraform/issues/6")
+class UseFirstClassExpressionsTest : HclRecipeTest {
+    override val recipe: Recipe
+        get() = UseFirstClassExpressions()
+
+    @Test
+    fun removeCurlyBracesFromTemplate() = assertChanged(
+        before = """
+            variable "ami" {}
+            variable "instance_type" {}
+            variable "vpc_security_group_ids" {
+              type = "list"
+            }
+
+            resource "aws_instance" "example" {
+              ami                     = "${'$'}{var.ami}"
+              instance_type           = "${'$'}{var.instance_type}"
+
+              vpc_security_group_ids  = "${'$'}{var.vpc_security_group_ids}"
+            }
+        """,
+        after = """
+            variable "ami" {}
+            variable "instance_type" {}
+            variable "vpc_security_group_ids" {
+              type = "list"
+            }
+
+            resource "aws_instance" "example" {
+              ami                     = var.ami
+              instance_type           = var.instance_type
+
+              vpc_security_group_ids  = var.vpc_security_group_ids
+            }
+        """
+    )
+
+    @Test
+    fun doNotChangeExistingUpdatedExpressionSyntax() = assertUnchanged(
+        before = """
+            variable "ami" {}
+            variable "instance_type" {}
+            variable "vpc_security_group_ids" {
+              type = "list"
+            }
+
+            resource "aws_instance" "example" {
+              ami                    = var.ami
+              instance_type          = var.instance_type
+
+              vpc_security_group_ids = var.vpc_security_group_ids
+            }
+        """
+    )
+
+    @Test
+    @Disabled
+    @Issue("https://github.com/openrewrite/rewrite-terraform/issues/7")
+    fun removeCurlyBracesFromFunctions() = assertChanged(
+        before = """
+            tags = "${'$'}{merge(map("Name", "example"), var.common_tags)}"
+        """,
+        after = """
+            tags = merge({ Name = "example" }, var.common_tags)
+        """
+    )
+
+    @Test
+    @Disabled
+    fun expressionsWithListsAndMaps() = assertChanged(
+        before = """
+            resource "aws_instance" "example" {
+              # The following works because the list structure is static
+              vpc_security_group_ids = ["${'$'}{var.security_group_1}", "${'$'}{var.security_group_2}"]
+
+              # The following doesn't work, because the [...] syntax isn't known to the interpolation language
+              vpc_security_group_ids = "${'$'}{var.security_group_id != "" ? [var.security_group_id] : []}"
+
+              # Instead, it's necessary to use the list() function
+              vpc_security_group_ids = "${'$'}{var.security_group_id != "" ? list(var.security_group_id) : list()}"
+            }
+        """,
+        after = """
+            resource "aws_instance" "example" {
+              vpc_security_group_ids = var.security_group_id != "" ? [var.security_group_id] : []
+            }
+        """
+    )
+
+}


### PR DESCRIPTION
Starts the ball rolling. Putting out scaffolding.

Part of https://github.com/openrewrite/rewrite-terraform/issues/1
Part of https://github.com/openrewrite/rewrite-terraform/issues/6