### PR TITLE
Unpin version of gradle enterprise

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,7 +8,7 @@ pluginManagement {
 rootProject.name = "rewrite-terraform"
 
 plugins {
-    id("com.gradle.enterprise") version "3.11"
+    id("com.gradle.enterprise") version "latest.release"
     id("com.gradle.common-custom-user-data-gradle-plugin") version "latest.release"
 }
 


### PR DESCRIPTION
## What's changed?
Switch from `3.11` to `latest.release`

## What's your motivation?
https://github.com/openrewrite/rewrite/pull/3314

## Anyone you would like to review specifically?
@jprinet